### PR TITLE
ignoring api files with no comments

### DIFF
--- a/lib/swagger-koa/index.js
+++ b/lib/swagger-koa/index.js
@@ -165,8 +165,10 @@ function createParserCb(fn) {
 
         cb();
       });
-    }, function(err) {
-      resources[resource.resourcePath] = resource;
+    }, function() {
+      if (resource.resourcePath){
+        resources[resource.resourcePath] = resource;
+      }
       fn();
     });
   };


### PR DESCRIPTION
when including api files   (using glob or other method) with no jsdoc comments routes are not created
